### PR TITLE
Fix clock inverter inclusion bug

### DIFF
--- a/src/bag3_digital/layout/stdcells/memory.py
+++ b/src/bag3_digital/layout/stdcells/memory.py
@@ -432,6 +432,7 @@ class FlopCore(MOSBase):
             ncol = cur_col + m_ncol + s_ncol + blk_sp + inv_master.num_cols + m_inv_sp
             scol = cur_col + m_ncol + inv_master.num_cols + blk_sp + m_inv_sp + extra_sp
             b_inst = self.add_tile(inv_master, 0, cur_col + m_ncol + m_inv_sp)
+            inst_list.append(b_inst)
             self._cntr_col_clk = scol - (blk_sp + extra_sp) // 2
         else:
             ncol = cur_col + m_ncol + s_ncol + blk_sp


### PR DESCRIPTION
Fixes bug where if seg_ck != 0, the clock inverter is created, but does not get added to the inst_lists and therefore does not get its supply nets included in the vdd/vss lists